### PR TITLE
Suppress merging columns with inherited definition notices

### DIFF
--- a/bootstrap.sql
+++ b/bootstrap.sql
@@ -139,13 +139,13 @@ CREATE OR REPLACE FUNCTION zbx_provision_partitions(
 
 			EXCEPTION WHEN undefined_table THEN
 				-- create missing table, copying schema from parent table
-				EXECUTE 'CREATE TABLE ' || schema_name || '.' || new_table_name || ' (
-					LIKE ' || table_name || '
-						INCLUDING DEFAULTS
-						INCLUDING CONSTRAINTS
-						INCLUDING INDEXES
-				) INHERITS (' || table_name || ');';
-
+                                EXECUTE 'CREATE TABLE ' || schema_name || '.' || new_table_name || ' (
+                                        LIKE ' || table_name || '
+                                                INCLUDING DEFAULTS
+                                                INCLUDING CONSTRAINTS
+                                                INCLUDING INDEXES);';
+                                -- add inheritance
+                                EXECUTE 'ALTER TABLE ' || schema_name || '.' || new_table_name || ' INHERIT ' || table_name || ';';
 				-- add clock column constraint
 				EXECUTE 'ALTER TABLE ' || schema_name || '.' || new_table_name
 					|| ' ADD CONSTRAINT ' || new_constraint_name


### PR DESCRIPTION
On new partition create there are a lot of notices like below:
```
NOTICE:  merging column "itemid" with inherited definition
CONTEXT:  SQL statement "CREATE TABLE partitions.history_2017_11_10 (
                                        LIKE history
                                                INCLUDING DEFAULTS
                                                INCLUDING CONSTRAINTS
                                                INCLUDING INDEXES
                                ) INHERITS (history);"
PL/pgSQL function zbx_provision_partitions(text,text,bigint,text) line 32 at EXECUTE statement
NOTICE:  merging column "clock" with inherited definition
CONTEXT:  SQL statement "CREATE TABLE partitions.history_2017_11_10 (
                                        LIKE history
                                                INCLUDING DEFAULTS
                                                INCLUDING CONSTRAINTS
                                                INCLUDING INDEXES
                                ) INHERITS (history);"
PL/pgSQL function zbx_provision_partitions(text,text,bigint,text) line 32 at EXECUTE statement
NOTICE:  merging column "value" with inherited definition
CONTEXT:  SQL statement "CREATE TABLE partitions.history_2017_11_10 (
                                        LIKE history
                                                INCLUDING DEFAULTS
                                                INCLUDING CONSTRAINTS
                                                INCLUDING INDEXES
                                ) INHERITS (history);"
PL/pgSQL function zbx_provision_partitions(text,text,bigint,text) line 32 at EXECUTE statement
NOTICE:  merging column "ns" with inherited definition
CONTEXT:  SQL statement "CREATE TABLE partitions.history_2017_11_10 (
                                        LIKE history
                                                INCLUDING DEFAULTS
                                                INCLUDING CONSTRAINTS
                                                INCLUDING INDEXES
                                ) INHERITS (history);"
PL/pgSQL function zbx_provision_partitions(text,text,bigint,text) line 32 at EXECUTE statement

```

To suppress notice generation split table creation in two parts:
1. Creating partion table like master table
2. Add inheritance between master and new partition table